### PR TITLE
Cauldron - ConversationPersistence & Restore

### DIFF
--- a/Cauldron/Interfaces/IConversationStorageService.cs
+++ b/Cauldron/Interfaces/IConversationStorageService.cs
@@ -1,0 +1,27 @@
+namespace Cauldron.Interfaces;
+
+/// <summary>
+/// Service for managing conversation ID persistence across browser sessions.
+/// Abstracts the storage mechanism (ProtectedLocalStorage) for conversation state tracking.
+/// </summary>
+public interface IConversationStorageService
+{
+    /// <summary>
+    /// Retrieves the saved conversation ID from protected browser storage.
+    /// </summary>
+    /// <returns>
+    /// The conversation ID if found and successfully decrypted; otherwise, null.
+    /// </returns>
+    Task<string?> GetConversationIdAsync();
+
+    /// <summary>
+    /// Saves the conversation ID to protected browser storage with automatic encryption.
+    /// </summary>
+    /// <param name="conversationId">Unique conversation identifier to persist</param>
+    Task SaveConversationIdAsync(string conversationId);
+
+    /// <summary>
+    /// Clears the saved conversation ID from protected browser storage.
+    /// </summary>
+    Task ClearConversationIdAsync();
+}

--- a/Cauldron/Messages/ConversationResumeResponse.cs
+++ b/Cauldron/Messages/ConversationResumeResponse.cs
@@ -1,0 +1,22 @@
+namespace Cauldron.Messages;
+
+/// <summary>
+/// Response model from POST /api/conversation/{id}/resume endpoint.
+/// </summary>
+public class ConversationResumeResponse
+{
+    /// <summary>
+    /// Unique identifier of the resumed conversation.
+    /// </summary>
+    public string ConversationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates whether the conversation was successfully resumed.
+    /// </summary>
+    public bool Resumed { get; set; }
+
+    /// <summary>
+    /// Name of the active agent when conversation was persisted.
+    /// </summary>
+    public string ActiveAgent { get; set; } = string.Empty;
+}

--- a/Cauldron/Pages/Index.razor
+++ b/Cauldron/Pages/Index.razor
@@ -24,14 +24,10 @@
                     @(isConnected ? "Online" : "Offline")
                 </span>
             </div>
-            
-            @if (isInitialized && !string.IsNullOrEmpty(conversationId))
-            {
-                <button class="new-conversation-btn" @onclick="StartNewConversation" title="Start a new conversation">
-                    <span class="btn-icon">✨</span>
-                    <span class="btn-text">New Conversation</span>
-                </button>
-            }
+            <button class="new-conversation-btn" disabled="@IsNewConversationButtonDisabled" @onclick="ClearAndStartNewConversation" title="Start a new conversation">
+                <span class="btn-icon">✨</span>
+                <span class="btn-text">New Conversation</span>
+            </button>
         </div>
     </div>
 
@@ -125,7 +121,7 @@
             class="message-input @(IsSpecializedAgent(currentAgentName) ? "agent" : "morgana")"></textarea>
         <button
             @onclick="SendMessage"
-            disabled="@IsButtonDisabled"
+            disabled="@IsSendButtonDisabled"
             class="send-button @(isSending ? "sending" : "") @(IsSpecializedAgent(currentAgentName) ? "agent" : "morgana")">
             <!-- Animated cauldron icon with magical effects -->
             <span class="cauldron-wrapper">
@@ -165,48 +161,48 @@
     // =========================================================================
     // STATE VARIABLES
     // =========================================================================
-    
+
     /// <summary>
     /// List of all chat messages in the current conversation.
     /// Includes user messages, agent responses, typing indicators, and presentation messages.
     /// </summary>
     private List<ChatMessage> messages = [];
-    
+
     /// <summary>
     /// Current text input from the user (two-way bound to textarea).
     /// </summary>
     private string inputText = string.Empty;
-    
+
     /// <summary>
     /// Unique identifier for the current conversation.
     /// Generated on conversation start and used for message routing.
     /// </summary>
     private string conversationId = string.Empty;
-    
+
     /// <summary>
     /// SignalR connection state indicator.
     /// True when connected and ready to receive messages.
     /// </summary>
     private bool isConnected = false;
-    
+
     /// <summary>
     /// Message send operation in progress indicator.
     /// True during HTTP POST to prevent duplicate sends.
     /// </summary>
     private bool isSending = false;
-    
+
     /// <summary>
     /// Initialization complete indicator.
     /// True after SignalR connection and conversation start succeed.
     /// </summary>
     private bool isInitialized = false;
-    
+
     /// <summary>
     /// Error message to display in error banner.
     /// Empty string when no error present.
     /// </summary>
     private string errorMessage = string.Empty;
-    
+
     /// <summary>
     /// Name of the currently active agent.
     /// Updates dynamically when agents take control: "Morgana", "Billing", etc.
@@ -253,7 +249,7 @@
             {
                 await HandleMessageReceived(conversationId, text, timestamp, quickReplies, agentName, agentCompleted);
             };
-            
+
             // Subscribe to connection state changes
             SignalRService.OnConnectionStateChanged += (connected) =>
             {
@@ -262,57 +258,47 @@
                 InvokeAsync(StateHasChanged);
             };
 
-            Console.WriteLine("🔵 Initialization complete, waiting for first render to check storage");
+            Console.WriteLine("🔵 Initialization complete. Checking storage for existing conversation...");
+
+            if (!hasCheckedStorage)
+            {
+                hasCheckedStorage = true;
+
+                try
+                {
+                    // Check ProtectedLocalStorage for saved conversation ID
+                    string? savedConversationId = await StorageService.GetConversationIdAsync();
+
+                    if (!string.IsNullOrEmpty(savedConversationId))
+                    {
+                        Console.WriteLine($"🔵 Found saved conversation ID: {savedConversationId}");
+                        await ResumeConversation(savedConversationId);
+                    }
+                    else
+                    {
+                        Console.WriteLine("🔵 No saved conversation found, starting new");
+                        await StartConversation();
+                    }
+
+                    isInitialized = true;
+                    errorMessage = string.Empty;
+                    Console.WriteLine($"🔵 Initialized with conversationId: {conversationId}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Storage check error: {ex.Message}");
+                    errorMessage = $"Initialization error: {ex.Message}";
+                }
+                finally
+                {
+                    await InvokeAsync(StateHasChanged);
+                }
+            }
         }
         catch (Exception ex)
         {
             Console.WriteLine($"❌ Initialization error: {ex.Message}");
             errorMessage = $"Initialization error: {ex.Message}";
-        }
-    }
-
-    /// <summary>
-    /// Blazor lifecycle method called after component renders.
-    /// Checks ProtectedLocalStorage for saved conversation ID on first render only.
-    /// ProtectedLocalStorage requires JavaScript interop, so must be called after first render.
-    /// </summary>
-    /// <param name="firstRender">True if this is the first render of the component</param>
-    /// <returns>Task representing the async after-render operations</returns>
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender && !hasCheckedStorage)
-        {
-            hasCheckedStorage = true;
-            
-            try
-            {
-                // Check ProtectedLocalStorage for saved conversation ID
-                string? savedConversationId = await StorageService.GetConversationIdAsync();
-                
-                if (!string.IsNullOrEmpty(savedConversationId))
-                {
-                    Console.WriteLine($"🔵 Found saved conversation ID: {savedConversationId}");
-                    await ResumeConversation(savedConversationId);
-                }
-                else
-                {
-                    Console.WriteLine("🔵 No saved conversation found, starting new");
-                    await StartConversation();
-                }
-
-                isInitialized = true;
-                errorMessage = string.Empty;
-                Console.WriteLine($"🔵 Initialized with conversationId: {conversationId}");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"❌ Storage check error: {ex.Message}");
-                errorMessage = $"Initialization error: {ex.Message}";
-            }
-            finally
-            {
-                await InvokeAsync(StateHasChanged);
-            }
         }
     }
 
@@ -357,8 +343,12 @@
                 // Successfully resumed
                 ConversationResumeResponse? result = await response.Content
                     .ReadFromJsonAsync<ConversationResumeResponse>();
-                
+
                 conversationId = result?.ConversationId ?? savedConversationId;
+                if (string.IsNullOrEmpty(result?.ActiveAgent))
+                    currentAgentName = "Morgana";
+                else
+                    currentAgentName = $"Morgana ({char.ToUpper(result.ActiveAgent[0]) + result.ActiveAgent.Substring(1)})";
 
                 Console.WriteLine($"🟡 Conversation resumed: {conversationId}, Active agent: {result?.ActiveAgent}");
 
@@ -371,11 +361,11 @@
                 messages.Add(new ChatMessage
                 {
                     ConversationId = conversationId,
-                    Text = "✨ Conversation resumed. Welcome back!",
+                    Text = $"✨ Conversation resumed. {currentAgentName} back to you!",
                     Role = "assistant",
                     Timestamp = DateTime.Now,
-                    AgentName = "Morgana",
-                    Type = MessageType.Presentation
+                    AgentName = currentAgentName,
+                    Type = MessageType.Assistant
                 });
                 
                 await InvokeAsync(StateHasChanged);
@@ -483,11 +473,11 @@
     /// Triggered by the "+ New Conversation" button.
     /// </summary>
     /// <returns>Task representing the async new conversation operation</returns>
-    private async Task StartNewConversation()
+    private async Task ClearAndStartNewConversation()
     {
         try
         {
-            Console.WriteLine("🆕 StartNewConversation: Clearing storage and refreshing...");
+            Console.WriteLine("🆕 ClearAndStartNewConversation: Clearing storage and refreshing...");
             
             // Clear saved conversation ID from ProtectedLocalStorage
             await StorageService.ClearConversationIdAsync();
@@ -497,7 +487,7 @@
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"❌ StartNewConversation exception: {ex.Message}");
+            Console.WriteLine($"❌ ClearAndStartNewConversation exception: {ex.Message}");
             errorMessage = $"Error starting new conversation: {ex.Message}";
         }
     }
@@ -584,7 +574,8 @@
                         Role = "assistant",
                         Timestamp = DateTime.Now,
                         IsError = true,
-                        AgentName = "Morgana"
+                        AgentName = currentAgentName,
+                        Type = MessageType.Error
                     });
                     StateHasChanged();
                 }
@@ -608,7 +599,8 @@
                     Role = "assistant",
                     Timestamp = DateTime.Now,
                     IsError = true,
-                    AgentName = "Morgana"
+                    AgentName = currentAgentName,
+                    Type = MessageType.Error
                 });
 
                 errorMessage = $"Error: {ex.Message}";
@@ -770,13 +762,23 @@
     /// Gets a value indicating whether the send button should be disabled.
     /// Disabled when: not connected, sending in progress, empty input, not initialized, has active quick replies, or typing indicator present.
     /// </summary>
-    private bool IsButtonDisabled =>
+    private bool IsSendButtonDisabled =>
         !isConnected ||
         isSending ||
         string.IsNullOrWhiteSpace(inputText) ||
         !isInitialized ||
         HasActiveQuickReplies() ||
         messages.Any(m => m.IsTyping);
+
+    /// <summary>
+    /// Gets a value indicating whether the new conversation button should be disabled.
+    /// Disabled when: not connected, not initialized, not checked for storage.
+    /// </summary>
+    private bool IsNewConversationButtonDisabled =>
+        !isConnected &&
+        !isInitialized &&
+        !hasCheckedStorage &&
+        string.IsNullOrWhiteSpace(conversationId);
 
     /// <summary>
     /// Gets a value indicating whether the textarea should be disabled.

--- a/Cauldron/Pages/Index.razor
+++ b/Cauldron/Pages/Index.razor
@@ -345,11 +345,15 @@
                     .ReadFromJsonAsync<ConversationResumeResponse>();
 
                 conversationId = result?.ConversationId ?? savedConversationId;
-                if (string.IsNullOrEmpty(result?.ActiveAgent))
+                if (string.IsNullOrEmpty(result?.ActiveAgent)
+                     || string.Equals(result.ActiveAgent, "Morgana", StringComparison.OrdinalIgnoreCase))
+                {
                     currentAgentName = "Morgana";
+                }
                 else
+                {
                     currentAgentName = $"Morgana ({char.ToUpper(result.ActiveAgent[0]) + result.ActiveAgent.Substring(1)})";
-
+                }
                 Console.WriteLine($"🟡 Conversation resumed: {conversationId}, Active agent: {result?.ActiveAgent}");
 
                 // Join SignalR group
@@ -361,7 +365,7 @@
                 messages.Add(new ChatMessage
                 {
                     ConversationId = conversationId,
-                    Text = $"✨ Conversation resumed. {currentAgentName} back to you!",
+                    Text = $"✨ Conversation resumed (found in parchment '{conversationId}'). {currentAgentName} back to you!",
                     Role = "assistant",
                     Timestamp = DateTime.Now,
                     AgentName = currentAgentName,

--- a/Cauldron/Pages/Index.razor
+++ b/Cauldron/Pages/Index.razor
@@ -2,6 +2,8 @@
 @using Cauldron.Services
 @inject MorganaSignalRService SignalRService
 @inject MorganaLandingMessageService LandingMessageService
+@inject IConversationStorageService StorageService
+@inject NavigationManager NavigationManager
 @inject HttpClient Http
 @inject IConfiguration Configuration
 @implements IAsyncDisposable
@@ -15,21 +17,30 @@
             <img src="images/morgana-avatar.png" 
                  alt="Morgana" 
                  class="header-avatar"
-                 style="border: 3px solid @GetAvatarBorderColor(currentAgentName); !important" />
+                 style="border: 3px solid @GetAvatarBorderColor(currentAgentName);" />
             <div class="header-info">
                 <h1 style="color: @GetAvatarBorderColor(currentAgentName);">@currentAgentName</h1>
                 <span class="status @(isConnected ? "online" : "offline")" style="color: @(isConnected ? "#10b981" : "#ef4444");">
                     @(isConnected ? "Online" : "Offline")
                 </span>
             </div>
+            
+            @if (isInitialized && !string.IsNullOrEmpty(conversationId))
+            {
+                <button class="new-conversation-btn" @onclick="StartNewConversation" title="Start a new conversation">
+                    <span class="btn-icon">✨</span>
+                    <span class="btn-text">New Conversation</span>
+                </button>
+            }
         </div>
     </div>
 
     <!-- Messages Area -->
     <div class="messages-container">
-        @if (!isInitialized || messages.Count == 0)
+        @if (messages.Count == 0)
         {
             <!-- Loading state with magical animation -->
+            <!-- Loader visible until first message arrives from backend (presentation or conversation history) -->
             <div class="magical-loader">
                 <div class="magic-sparkle-core">
                     <div class="glow-core"></div>
@@ -208,13 +219,19 @@
     /// </summary>
     private string landingMessage = string.Empty;
 
+    /// <summary>
+    /// Flag to track if storage has been checked (prevents multiple checks on re-renders).
+    /// </summary>
+    private bool hasCheckedStorage = false;
+
     // =========================================================================
     // LIFECYCLE METHODS
     // =========================================================================
 
     /// <summary>
     /// Blazor lifecycle method called when component is initialized.
-    /// Sets up SignalR connection, subscribes to events, and starts conversation.
+    /// Sets up SignalR connection and subscribes to events.
+    /// Note: ProtectedLocalStorage check moved to OnAfterRenderAsync for JavaScript interop availability.
     /// </summary>
     /// <returns>Task representing the async initialization</returns>
     protected override async Task OnInitializedAsync()
@@ -245,20 +262,57 @@
                 InvokeAsync(StateHasChanged);
             };
 
-            // Start conversation and get presentation message
-            await StartConversation();
-            isInitialized = true;
-            errorMessage = string.Empty;
-            Console.WriteLine($"🔵 Initialized with conversationId: {conversationId}");
+            Console.WriteLine("🔵 Initialization complete, waiting for first render to check storage");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"❌ Initialization error: {ex.Message}");
             errorMessage = $"Initialization error: {ex.Message}";
         }
-        finally
+    }
+
+    /// <summary>
+    /// Blazor lifecycle method called after component renders.
+    /// Checks ProtectedLocalStorage for saved conversation ID on first render only.
+    /// ProtectedLocalStorage requires JavaScript interop, so must be called after first render.
+    /// </summary>
+    /// <param name="firstRender">True if this is the first render of the component</param>
+    /// <returns>Task representing the async after-render operations</returns>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !hasCheckedStorage)
         {
-            StateHasChanged();
+            hasCheckedStorage = true;
+            
+            try
+            {
+                // Check ProtectedLocalStorage for saved conversation ID
+                string? savedConversationId = await StorageService.GetConversationIdAsync();
+                
+                if (!string.IsNullOrEmpty(savedConversationId))
+                {
+                    Console.WriteLine($"🔵 Found saved conversation ID: {savedConversationId}");
+                    await ResumeConversation(savedConversationId);
+                }
+                else
+                {
+                    Console.WriteLine("🔵 No saved conversation found, starting new");
+                    await StartConversation();
+                }
+
+                isInitialized = true;
+                errorMessage = string.Empty;
+                Console.WriteLine($"🔵 Initialized with conversationId: {conversationId}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"❌ Storage check error: {ex.Message}");
+                errorMessage = $"Initialization error: {ex.Message}";
+            }
+            finally
+            {
+                await InvokeAsync(StateHasChanged);
+            }
         }
     }
 
@@ -267,8 +321,103 @@
     // =========================================================================
 
     /// <summary>
+    /// Resumes an existing conversation from ProtectedLocalStorage.
+    /// If resume fails (404), automatically falls back to starting a new conversation.
+    /// </summary>
+    /// <param name="savedConversationId">The conversation ID retrieved from storage</param>
+    /// <returns>Task representing the async resume operation</returns>
+    /// <remarks>
+    /// <para><strong>Resume Flow:</strong></para>
+    /// <list type="number">
+    /// <item>POST to /api/conversation/{id}/resume</item>
+    /// <item>Backend restores actor hierarchy and loads AgentThread from SQLite</item>
+    /// <item>Join SignalR group for this conversation</item>
+    /// <item>Backend may send welcome-back message via SignalR (optional)</item>
+    /// </list>
+    /// <para><strong>Fallback Scenarios:</strong></para>
+    /// <list type="bullet">
+    /// <item><term>404 Not Found</term><description>Conversation expired/deleted → Clear storage and start new</description></item>
+    /// <item><term>500 Server Error</term><description>Backend error → Clear storage and start new</description></item>
+    /// <item><term>Network Error</term><description>Connection failure → Clear storage and start new</description></item>
+    /// </list>
+    /// </remarks>
+    private async Task ResumeConversation(string savedConversationId)
+    {
+        try
+        {
+            Console.WriteLine($"🟡 ResumeConversation: Attempting to resume {savedConversationId}");
+
+            HttpResponseMessage response = await Http.PostAsync(
+                $"/api/conversation/{savedConversationId}/resume", null);
+
+            Console.WriteLine($"🟡 Resume response status: {response.StatusCode}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                // Successfully resumed
+                ConversationResumeResponse? result = await response.Content
+                    .ReadFromJsonAsync<ConversationResumeResponse>();
+                
+                conversationId = result?.ConversationId ?? savedConversationId;
+
+                Console.WriteLine($"🟡 Conversation resumed: {conversationId}, Active agent: {result?.ActiveAgent}");
+
+                // Join SignalR group
+                await SignalRService.JoinConversation(conversationId);
+
+                // Add a system message to hide the loader
+                // Backend should send conversation history via SignalR, but if it doesn't,
+                // this placeholder ensures the loader disappears
+                messages.Add(new ChatMessage
+                {
+                    ConversationId = conversationId,
+                    Text = "✨ Conversation resumed. Welcome back!",
+                    Role = "assistant",
+                    Timestamp = DateTime.Now,
+                    AgentName = "Morgana",
+                    Type = MessageType.Presentation
+                });
+                
+                await InvokeAsync(StateHasChanged);
+
+                Console.WriteLine($"🟡 Joined SignalR group, waiting for conversation history...");
+                // Backend should send conversation history via SignalR
+            }
+            else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // Conversation not found in backend (expired or deleted)
+                Console.WriteLine($"⚠️ Conversation {savedConversationId} not found, starting fresh");
+                
+                // Clear corrupted/expired storage
+                await StorageService.ClearConversationIdAsync();
+                
+                // Fallback to new conversation
+                await StartConversation();
+            }
+            else
+            {
+                // Other error (500, etc.)
+                string errorContent = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"❌ Resume error {response.StatusCode}: {errorContent}");
+                
+                // Fallback to new conversation
+                await StorageService.ClearConversationIdAsync();
+                await StartConversation();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❌ ResumeConversation exception: {ex.Message}");
+            
+            // Fallback to new conversation on any error
+            await StorageService.ClearConversationIdAsync();
+            await StartConversation();
+        }
+    }
+
+    /// <summary>
     /// Starts a new conversation with Morgana backend.
-    /// Sends POST request to /api/conversation/start, joins SignalR group, and displays presentation message.
+    /// Sends POST request to /api/conversation/start, joins SignalR group, saves to storage, and displays presentation message.
     /// </summary>
     /// <returns>Task representing the async conversation start operation</returns>
     /// <remarks>
@@ -278,6 +427,7 @@
     /// <item>POST to /api/conversation/start</item>
     /// <item>Extract conversationId from response</item>
     /// <item>Join SignalR conversation group</item>
+    /// <item>Save conversationId to ProtectedLocalStorage</item>
     /// <item>Wait for presentation message via SignalR</item>
     /// <item>Display presentation with quick replies</item>
     /// </list>
@@ -299,13 +449,17 @@
             if (response.IsSuccessStatusCode)
             {
                 // Parse response to get conversation ID
-                var result = await response.Content.ReadFromJsonAsync<ConversationStartResponse>();
+                ConversationStartResponse? result = await response.Content.ReadFromJsonAsync<ConversationStartResponse>();
                 conversationId = result?.ConversationId ?? string.Empty;
 
                 Console.WriteLine($"🟢 Conversation started: {conversationId}");
 
                 // Join SignalR group for this conversation
                 await SignalRService.JoinConversation(conversationId);
+
+                // Save conversation ID to ProtectedLocalStorage
+                await StorageService.SaveConversationIdAsync(conversationId);
+                Console.WriteLine($"🟢 Conversation ID saved to protected storage");
 
                 Console.WriteLine($"🟢 Waiting for presentation message...");
                 // Presentation message will arrive via SignalR OnMessageReceived event
@@ -321,6 +475,30 @@
         {
             Console.WriteLine($"❌ StartConversation exception: {ex.Message}");
             errorMessage = $"Error: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Clears the saved conversation ID and refreshes the page to start a new conversation.
+    /// Triggered by the "+ New Conversation" button.
+    /// </summary>
+    /// <returns>Task representing the async new conversation operation</returns>
+    private async Task StartNewConversation()
+    {
+        try
+        {
+            Console.WriteLine("🆕 StartNewConversation: Clearing storage and refreshing...");
+            
+            // Clear saved conversation ID from ProtectedLocalStorage
+            await StorageService.ClearConversationIdAsync();
+            
+            // Force page reload to trigger OnInitializedAsync with fresh state
+            NavigationManager.NavigateTo("/", forceLoad: true);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❌ StartNewConversation exception: {ex.Message}");
+            errorMessage = $"Error starting new conversation: {ex.Message}";
         }
     }
 
@@ -642,7 +820,7 @@
     /// </summary>
     /// <param name="agentName">Agent name to check</param>
     /// <returns>True if specialized agent, false if base Morgana</returns>
-    private bool IsSpecializedAgent(string agentName)
+    private bool IsSpecializedAgent(string? agentName)
     {
         return agentName != null && agentName.Contains("(") && agentName.Contains(")");
     }
@@ -669,11 +847,7 @@
     /// <returns>Formatted completion message</returns>
     private string GetCompletionMessage(string agentName)
     {
-        // For specialized agents, use configured template
-        if (agentName.Contains("(") && agentName.Contains(")"))
-            return string.Format(Configuration["Morgana:AgentExitMessage"]!, agentName);
-
-        // Default fallback
-        return "The spell has been completed";
+        string template = Configuration["Morgana:AgentExitMessage"] ?? "{0} has completed its spell. I'm back to you!";
+        return string.Format(template, agentName);
     }
 }

--- a/Cauldron/Pages/Index.razor
+++ b/Cauldron/Pages/Index.razor
@@ -24,7 +24,7 @@
                     @(isConnected ? "Online" : "Offline")
                 </span>
             </div>
-            <button class="new-conversation-btn @(IsNewConversationButtonVisible ? "visible" : "hidden")" @onclick="ClearConversation" title="Start a new conversation">
+            <button class="new-conversation-btn @(IsNewConversationButtonVisible ? "visible" : "hidden")" @onclick="ClearConversation" title="Start a new conversation with Morgana">
                 <span class="btn-icon">✨</span>
                 <span class="btn-text">New Conversation</span>
             </button>
@@ -776,10 +776,13 @@
 
     /// <summary>
     /// Gets a value indicating whether the new conversation button should be visible.
-    /// Visible when: connected and initialized and checked for storage.
     /// </summary>
     private bool IsNewConversationButtonVisible =>
-        isConnected && isInitialized && hasCheckedStorage && !string.IsNullOrWhiteSpace(conversationId);
+        isConnected
+         && isInitialized
+         && hasCheckedStorage
+         && !string.IsNullOrWhiteSpace(conversationId)
+         && messages.Count > 0;
 
     /// <summary>
     /// Gets a value indicating whether the textarea should be disabled.

--- a/Cauldron/Pages/Index.razor
+++ b/Cauldron/Pages/Index.razor
@@ -24,7 +24,7 @@
                     @(isConnected ? "Online" : "Offline")
                 </span>
             </div>
-            <button class="new-conversation-btn" disabled="@IsNewConversationButtonDisabled" @onclick="ClearAndStartNewConversation" title="Start a new conversation">
+            <button class="new-conversation-btn @(IsNewConversationButtonVisible ? "visible" : "hidden")" @onclick="ClearConversation" title="Start a new conversation">
                 <span class="btn-icon">✨</span>
                 <span class="btn-text">New Conversation</span>
             </button>
@@ -205,7 +205,7 @@
 
     /// <summary>
     /// Name of the currently active agent.
-    /// Updates dynamically when agents take control: "Morgana", "Billing", etc.
+    /// Updates dynamically when agents take control: "Morgana", "Morgana (Billing)", etc.
     /// Displayed in header and used for avatar border color.
     /// </summary>
     private string currentAgentName = "Morgana";
@@ -477,11 +477,11 @@
     /// Triggered by the "+ New Conversation" button.
     /// </summary>
     /// <returns>Task representing the async new conversation operation</returns>
-    private async Task ClearAndStartNewConversation()
+    private async Task ClearConversation()
     {
         try
         {
-            Console.WriteLine("🆕 ClearAndStartNewConversation: Clearing storage and refreshing...");
+            Console.WriteLine($"🆕 {nameof(ClearConversation)}: Clearing storage and refreshing...");
             
             // Clear saved conversation ID from ProtectedLocalStorage
             await StorageService.ClearConversationIdAsync();
@@ -491,7 +491,7 @@
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"❌ ClearAndStartNewConversation exception: {ex.Message}");
+            Console.WriteLine($"❌ {nameof(ClearConversation)} exception: {ex.Message}");
             errorMessage = $"Error starting new conversation: {ex.Message}";
         }
     }
@@ -775,14 +775,11 @@
         messages.Any(m => m.IsTyping);
 
     /// <summary>
-    /// Gets a value indicating whether the new conversation button should be disabled.
-    /// Disabled when: not connected, not initialized, not checked for storage.
+    /// Gets a value indicating whether the new conversation button should be visible.
+    /// Visible when: connected and initialized and checked for storage.
     /// </summary>
-    private bool IsNewConversationButtonDisabled =>
-        !isConnected &&
-        !isInitialized &&
-        !hasCheckedStorage &&
-        string.IsNullOrWhiteSpace(conversationId);
+    private bool IsNewConversationButtonVisible =>
+        isConnected && isInitialized && hasCheckedStorage && !string.IsNullOrWhiteSpace(conversationId);
 
     /// <summary>
     /// Gets a value indicating whether the textarea should be disabled.

--- a/Cauldron/Pages/_Host.cshtml
+++ b/Cauldron/Pages/_Host.cshtml
@@ -21,10 +21,11 @@
 
         <!-- Stylesheet Imports -->
         <!-- Loaded in order: base styles → component styles → specialized features -->
-        <link href="css/site.css" rel="stylesheet" />           <!-- Base site styles and variables -->
-        <link href="css/cauldron.css" rel="stylesheet" />       <!-- Chat interface styles -->
-        <link href="css/quick-reply.css" rel="stylesheet" />    <!-- Quick reply button styles -->
-        <link href="css/sparkle-loader.css" rel="stylesheet" /> <!-- Loading animation styles -->
+        <link href="css/site.css" rel="stylesheet" />                    <!-- Base site styles and variables -->
+        <link href="css/cauldron.css" rel="stylesheet" />                <!-- Chat interface styles -->
+        <link href="css/quick-reply.css" rel="stylesheet" />             <!-- Quick reply button styles -->
+        <link href="css/sparkle-loader.css" rel="stylesheet" />          <!-- Loading animation styles -->
+        <link href="css/new-conversation-button.css" rel="stylesheet" /> <!-- New conversation button style -->
     </head>
     <body>
         <!-- Blazor Server Root Component -->

--- a/Cauldron/Services/ProtectedLocalStorageService.cs
+++ b/Cauldron/Services/ProtectedLocalStorageService.cs
@@ -1,0 +1,74 @@
+using Cauldron.Interfaces;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Cauldron.Services;
+
+/// <summary>
+/// Implementation of conversation storage using ASP.NET Core ProtectedLocalStorage.
+/// Provides encrypted, persistent storage of conversation IDs across browser sessions.
+/// </summary>
+public class ProtectedLocalStorageService : IConversationStorageService
+{
+    private readonly ProtectedLocalStorage protectedLocalStore;
+    private readonly ILogger logger;
+    private const string StorageKey = "morgana_conversation";
+
+    public ProtectedLocalStorageService(
+        ProtectedLocalStorage protectedLocalStore,
+        ILogger logger)
+    {
+        this.protectedLocalStore = protectedLocalStore;
+        this.logger = logger;
+    }
+
+    public async Task<string?> GetConversationIdAsync()
+    {
+        try
+        {
+            ProtectedBrowserStorageResult<string> result = 
+                await protectedLocalStore.GetAsync<string>(StorageKey);
+            
+            if (result.Success)
+            {
+                logger.LogInformation($"Retrieved conversation ID from protected storage");
+                return result.Value;
+            }
+            
+            logger.LogInformation("No conversation ID found in protected storage");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to retrieve conversation ID, clearing corrupted data");
+            await ClearConversationIdAsync();
+            return null;
+        }
+    }
+
+    public async Task SaveConversationIdAsync(string conversationId)
+    {
+        try
+        {
+            await protectedLocalStore.SetAsync(StorageKey, conversationId);
+            logger.LogInformation($"Saved conversation ID to protected storage: {conversationId}");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to save conversation ID to protected storage");
+            throw;
+        }
+    }
+
+    public async Task ClearConversationIdAsync()
+    {
+        try
+        {
+            await protectedLocalStore.DeleteAsync(StorageKey);
+            logger.LogInformation("Cleared conversation ID from protected storage");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to clear conversation ID (may already be empty)");
+        }
+    }
+}

--- a/Cauldron/_Imports.razor
+++ b/Cauldron/_Imports.razor
@@ -56,6 +56,9 @@
 @* Reusable UI components (QuickReplyButton, etc.) *@
 @using Cauldron.Components
 
+@* Service contracts (IConversationStorageService, etc.) *@
+@using Cauldron.Interfaces
+
 @*
     ============================================================================
     NAMESPACE ORGANIZATION

--- a/Cauldron/wwwroot/css/new-conversation-button.css
+++ b/Cauldron/wwwroot/css/new-conversation-button.css
@@ -27,6 +27,12 @@
     /* Shadow for depth */
     box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-color) 30%, transparent);
 }
+.new-conversation-btn.visible {
+    display: flex;
+}
+.new-conversation-btn.hidden {
+    display: none;
+}
 
 /* Icon styling */
 .new-conversation-btn .btn-icon {
@@ -72,7 +78,7 @@
 }
 
 /* Responsive adjustments */
-@media (max-width: 768px) {
+@media (max-width: 640px) {
     .new-conversation-btn {
         padding: 8px 12px;
         font-size: 13px;
@@ -112,7 +118,7 @@
 .chat-header .header-content {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    /*justify-content: space-between;*/
     width: 100%;
 }
 
@@ -121,37 +127,3 @@
     flex: 0 1 auto;
     margin-right: 16px;
 }
-
-/* ==============================================================================
-   ALTERNATIVE POSITIONING OPTIONS
-   ============================================================================== 
-   Comment/uncomment based on your preferred button location:
-   ============================================================================== */
-
-/* Option 1: Top-right corner (absolute positioning) */
-/*
-.new-conversation-btn {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-}
-*/
-
-/* Option 2: Floating button (bottom-right) */
-/*
-.new-conversation-btn {
-    position: fixed;
-    bottom: 100px;
-    right: 24px;
-    z-index: 1000;
-    border-radius: 50%;
-    width: 56px;
-    height: 56px;
-    padding: 0;
-    justify-content: center;
-}
-
-.new-conversation-btn .btn-text {
-    display: none;
-}
-*/

--- a/Cauldron/wwwroot/css/new-conversation-button.css
+++ b/Cauldron/wwwroot/css/new-conversation-button.css
@@ -1,0 +1,157 @@
+/* ==============================================================================
+   NEW CONVERSATION BUTTON
+   ============================================================================== */
+
+.new-conversation-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    margin-left: auto; /* Push to right side of header */
+    background: var(--primary-color);
+    color: white;
+
+    /* Typography */
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+
+    /* Border and shape */
+    border: none;
+    border-radius: 12px;
+
+    /* Interaction */
+    cursor: pointer;
+    transition: all 0.3s ease;
+
+    /* Shadow for depth */
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-color) 30%, transparent);
+}
+
+/* Icon styling */
+.new-conversation-btn .btn-icon {
+    font-size: 16px;
+    display: inline-block;
+    animation: sparkle 2s ease-in-out infinite;
+}
+
+/* Text styling */
+.new-conversation-btn .btn-text {
+    display: inline-block;
+}
+
+/* Hover effect - brighten and lift */
+.new-conversation-btn:hover {
+    background: color-mix(in srgb, var(--primary-color) 85%, white);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-color) 40%, transparent);
+}
+
+/* Active/click effect - press down */
+.new-conversation-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--primary-color) 30%, transparent);
+}
+
+/* Focus state for accessibility */
+.new-conversation-btn:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 30%, transparent);
+}
+
+/* Sparkle animation for the icon */
+@keyframes sparkle {
+    0%, 100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.8;
+        transform: scale(1.1) rotate(15deg);
+    }
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .new-conversation-btn {
+        padding: 8px 12px;
+        font-size: 13px;
+    }
+
+    .new-conversation-btn .btn-text {
+        display: none; /* Hide text on mobile, keep icon only */
+    }
+
+    .new-conversation-btn .btn-icon {
+        font-size: 18px;
+    }
+}
+
+/* Alternative compact version (if header space is limited) */
+.new-conversation-btn.compact {
+    padding: 8px;
+    min-width: 40px;
+    justify-content: center;
+}
+
+.new-conversation-btn.compact .btn-text {
+    display: none;
+}
+
+.new-conversation-btn.compact .btn-icon {
+    margin: 0;
+}
+
+/* ==============================================================================
+   HEADER LAYOUT ADJUSTMENTS
+   ============================================================================== 
+   If your header needs adjustments to accommodate the button, consider:
+   ============================================================================== */
+
+/* Ensure header has space for the button */
+.chat-header .header-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+/* Ensure header info doesn't take all space */
+.chat-header .header-info {
+    flex: 0 1 auto;
+    margin-right: 16px;
+}
+
+/* ==============================================================================
+   ALTERNATIVE POSITIONING OPTIONS
+   ============================================================================== 
+   Comment/uncomment based on your preferred button location:
+   ============================================================================== */
+
+/* Option 1: Top-right corner (absolute positioning) */
+/*
+.new-conversation-btn {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+}
+*/
+
+/* Option 2: Floating button (bottom-right) */
+/*
+.new-conversation-btn {
+    position: fixed;
+    bottom: 100px;
+    right: 24px;
+    z-index: 1000;
+    border-radius: 50%;
+    width: 56px;
+    height: 56px;
+    padding: 0;
+    justify-content: center;
+}
+
+.new-conversation-btn .btn-text {
+    display: none;
+}
+*/

--- a/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
+++ b/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
@@ -356,7 +356,7 @@ public class MorganaAgent : MorganaActor
                 $"Agent response analysis: HasINT={hasInteractiveToken}, EndsWithQuestion={endsWithQuestion}, HasQR={hasQuickReplies}, IsCompleted={isCompleted}");
 
             // Persist updated conversation state to encrypted storage
-            await persistenceService.SaveConversationAsync(AgentIdentifier, aiAgentThread);
+            await persistenceService.SaveConversationAsync(AgentIdentifier, aiAgentThread, isCompleted);
             agentLogger.LogInformation($"Saved conversation state for {AgentIdentifier}");
 
             #if DEBUG

--- a/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
+++ b/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
@@ -178,7 +178,7 @@ public class MorganaAgent : MorganaActor
 
         // Extract AIContextProviderState if present
         JsonElement providerState = default;
-        if (serializedThread.TryGetProperty("AIContextProviderState", out JsonElement stateElement))
+        if (serializedThread.TryGetProperty("aiContextProviderState", out JsonElement stateElement))
             providerState = stateElement;
 
         // Recreate context provider from serialized state

--- a/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
+++ b/Morgana/Morgana.Framework/Abstractions/MorganaAgent.cs
@@ -319,8 +319,8 @@ public class MorganaAgent : MorganaActor
 
         try
         {
-            // Load existing conversation thread from encrypted storage, or create new thread
-            aiAgentThread ??= await persistenceService.LoadConversationAsync(AgentIdentifier, this);
+            // Load existing agent's conversation thread from encrypted storage, or create new thread
+            aiAgentThread ??= await persistenceService.LoadAgentConversationAsync(AgentIdentifier, this);
             if (aiAgentThread != null)
             {
                 agentLogger.LogInformation($"Loaded existing conversation thread for {AgentIdentifier}");
@@ -355,8 +355,8 @@ public class MorganaAgent : MorganaActor
             agentLogger.LogInformation(
                 $"Agent response analysis: HasINT={hasInteractiveToken}, EndsWithQuestion={endsWithQuestion}, HasQR={hasQuickReplies}, IsCompleted={isCompleted}");
 
-            // Persist updated conversation state to encrypted storage
-            await persistenceService.SaveConversationAsync(AgentIdentifier, aiAgentThread, isCompleted);
+            // Persist updated agent's conversation state to encrypted storage
+            await persistenceService.SaveAgentConversationAsync(AgentIdentifier, aiAgentThread, isCompleted);
             agentLogger.LogInformation($"Saved conversation state for {AgentIdentifier}");
 
             #if DEBUG

--- a/Morgana/Morgana.Framework/Actors/ConversationManagerActor.cs
+++ b/Morgana/Morgana.Framework/Actors/ConversationManagerActor.cs
@@ -72,16 +72,20 @@ public class ConversationManagerActor : MorganaActor
 
         if (supervisor is null)
         {
-            supervisor = await Context.System.GetOrCreateActor<ConversationSupervisorActor>("supervisor", msg.ConversationId);
+            supervisor = await Context.System.GetOrCreateActor<ConversationSupervisorActor>(
+                "supervisor", msg.ConversationId);
 
             Context.Watch(supervisor);
 
             actorLogger.Info("Supervisor created: {0}", supervisor.Path);
 
-            // Trigger automatic presentation
-            supervisor.Tell(new Records.GeneratePresentationMessage());
+            // Trigger automatic presentation (only in case of new conversation)
+            if (!msg.IsRestore)
+            {
+                supervisor.Tell(new Records.GeneratePresentationMessage());
 
-            actorLogger.Info("Presentation generation triggered");
+                actorLogger.Info("Presentation generation triggered");
+            }
         }
 
         senderRef.Tell(new Records.ConversationCreated(msg.ConversationId));
@@ -123,7 +127,8 @@ public class ConversationManagerActor : MorganaActor
 
         if (supervisor == null)
         {
-            supervisor = await Context.System.GetOrCreateActor<ConversationSupervisorActor>("supervisor", msg.ConversationId);
+            supervisor = await Context.System.GetOrCreateActor<ConversationSupervisorActor>(
+                "supervisor", msg.ConversationId);
 
             Context.Watch(supervisor);
 

--- a/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
+++ b/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
@@ -34,8 +34,7 @@ namespace Morgana.Framework.Interfaces;
 /// </code>
 /// <para><strong>Implementation Examples:</strong></para>
 /// <list type="bullet">
-/// <item><term>EncryptedFileConversationPersistenceService</term><description>Stores conversations in encrypted .morgana.json files</description></item>
-/// <item><term>SqlConversationPersistenceService</term><description>Stores conversations in SQL database (future)</description></item>
+/// <item><term>SqlConversationPersistenceService</term><description>Stores conversations in SQL database</description></item>
 /// <item><term>CosmosDbConversationPersistenceService</term><description>Stores conversations in Azure Cosmos DB (future)</description></item>
 /// </list>
 /// </remarks>

--- a/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
+++ b/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
@@ -47,6 +47,7 @@ public interface IConversationPersistenceService
     /// </summary>
     /// <param name="agentIdentifier">Unique identifier for the agent's conversation</param>
     /// <param name="agentThread">AgentThread instance containing the complete conversation state</param>
+    /// <param name="isCompleted">Flag indicating if the agent is signalling completion of the conversation</param>
     /// <param name="jsonSerializerOptions">JSON serialization options (optional, uses AgentAbstractionsJsonUtilities.DefaultOptions if null)</param>
     /// <returns>Task representing the async save operation</returns>
     /// <remarks>
@@ -60,6 +61,7 @@ public interface IConversationPersistenceService
     Task SaveConversationAsync(
         string agentIdentifier,
         AgentThread agentThread,
+        bool isCompleted,
         JsonSerializerOptions? jsonSerializerOptions = null);
 
     /// <summary>
@@ -93,5 +95,5 @@ public interface IConversationPersistenceService
     /// </summary>
     /// <param name="conversationId">Conversation identifier</param>
     /// <returns>Agent name (e.g., "billing") or null if conversation not found</returns>
-    Task<string?> GetMostRecentAgentAsync(string conversationId);
+    Task<string?> GetMostRecentActiveAgentAsync(string conversationId);
 }

--- a/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
+++ b/Morgana/Morgana.Framework/Interfaces/IConversationPersistenceService.cs
@@ -22,10 +22,10 @@ namespace Morgana.Framework.Interfaces;
 /// <para><strong>Usage Pattern:</strong></para>
 /// <code>
 /// // Save conversation after each turn
-/// await persistenceService.SaveConversationAsync(conversationId, agentThread);
+/// await persistenceService.SaveAgentConversationAsync(conversationId, agentThread);
 ///
 /// // Load conversation on subsequent requests
-/// AgentThread? restored = await persistenceService.LoadConversationAsync(conversationId, morganaAgent);
+/// AgentThread? restored = await persistenceService.LoadAgentConversationAsync(conversationId, morganaAgent);
 /// if (restored != null)
 /// {
 ///     // Continue conversation with restored state
@@ -41,7 +41,7 @@ namespace Morgana.Framework.Interfaces;
 public interface IConversationPersistenceService
 {
     /// <summary>
-    /// Saves the complete conversation state to persistent storage.
+    /// Saves the complete conversation state of the given agent to persistent storage.
     /// Serializes the AgentThread including message history, context variables, and metadata.
     /// </summary>
     /// <param name="agentIdentifier">Unique identifier for the agent's conversation</param>
@@ -57,7 +57,7 @@ public interface IConversationPersistenceService
     /// <para>Implementations should throw meaningful exceptions for I/O errors, encryption failures,
     /// or serialization errors to allow proper error handling by callers.</para>
     /// </remarks>
-    Task SaveConversationAsync(
+    Task SaveAgentConversationAsync(
         string agentIdentifier,
         AgentThread agentThread,
         bool isCompleted,
@@ -83,7 +83,7 @@ public interface IConversationPersistenceService
     /// <item>Return the fully restored AgentThread</item>
     /// </list>
     /// </remarks>
-    Task<AgentThread?> LoadConversationAsync(
+    Task<AgentThread?> LoadAgentConversationAsync(
         string agentIdentifier,
         Abstractions.MorganaAgent agent,
         JsonSerializerOptions? jsonSerializerOptions = null);

--- a/Morgana/Morgana.Framework/Providers/MorganaContextProvider.cs
+++ b/Morgana/Morgana.Framework/Providers/MorganaContextProvider.cs
@@ -1,3 +1,4 @@
+using Akka.Util.Internal;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
@@ -114,6 +115,13 @@ public class MorganaContextProvider : AIContextProvider
         if (serializedState.TryGetProperty(nameof(SharedVariableNames), out JsonElement sharedElement))
         {
             SharedVariableNames = sharedElement.Deserialize<HashSet<string>>(jsonSerializerOptions) ?? [];
+
+            // Ensure to propagate shared variables from deserialized context
+            foreach (string sharedVariableName in SharedVariableNames)
+            {
+                if (AgentContext.TryGetValue(sharedVariableName, out object? sharedVariableValue))
+                    OnSharedContextUpdate?.Invoke(sharedVariableName, sharedVariableValue);
+            }
         }
         else
         {

--- a/Morgana/Morgana.Framework/Records.cs
+++ b/Morgana/Morgana.Framework/Records.cs
@@ -52,8 +52,10 @@ public static class Records
     /// Request to create a new conversation and initialize the actor hierarchy.
     /// </summary>
     /// <param name="ConversationId">Unique identifier for the new conversation</param>
+    /// <param name="IsRestore">Flag indicating that the conversation is being created or restored</param>
     public record CreateConversation(
-        string ConversationId);
+        string ConversationId,
+        bool IsRestore);
 
     /// <summary>
     /// Request to terminate a conversation and stop all associated actors.

--- a/Morgana/Morgana.Framework/Services/SQLiteConversationPersistedService.cs
+++ b/Morgana/Morgana.Framework/Services/SQLiteConversationPersistedService.cs
@@ -58,7 +58,8 @@ public class SQLiteConversationPersistenceService : IConversationPersistenceServ
     private const int SchemaVersion = 1;
 
     // SQL statements
-    private const string InitializeDatabaseSQL = @"
+    private const string InitializeDatabaseSQL =
+        """
         CREATE TABLE IF NOT EXISTS morgana (
             agent_identifier TEXT PRIMARY KEY NOT NULL,
             agent_name TEXT UNIQUE NOT NULL,
@@ -68,27 +69,30 @@ public class SQLiteConversationPersistenceService : IConversationPersistenceServ
             last_update TEXT NOT NULL,
             is_active INTEGER NOT NULL DEFAULT 0
         );
-        
+
         CREATE INDEX IF NOT EXISTS idx_agent_name ON morgana(agent_name);
         CREATE INDEX IF NOT EXISTS idx_conversation_id ON morgana(conversation_id);
-    ";
+        """;
 
-    private const string SaveConversationSQL = @"
+    private const string SaveConversationSQL =
+        """
         INSERT INTO morgana (agent_identifier, agent_name, conversation_id, agent_thread, creation_date, last_update, is_active)
         VALUES (@agent_identifier, @agent_name, @conversation_id, @agent_thread, @creation_date, @last_update, @is_active)
         ON CONFLICT(agent_identifier) DO UPDATE SET
             agent_thread = excluded.agent_thread,
             last_update = @last_update,
             is_active = @is_active;
-    ";
+        """;
 
-    private const string LoadConversationSQL = @"
+    private const string LoadActiveConversationSQL =
+        """
         SELECT agent_thread FROM morgana WHERE agent_identifier = @agent_identifier AND is_active = 1;
-    ";
+        """;
 
-    private const string GetMostRecentActiveAgentSQL = @"
+    private const string GetMostRecentActiveAgentSQL =
+        """
         SELECT agent_name FROM morgana WHERE is_active = 1 ORDER BY last_update DESC LIMIT 1;
-    ";
+        """;
 
     /// <summary>
     /// Initializes a new instance of the SQLiteConversationPersistenceService.
@@ -225,7 +229,7 @@ public class SQLiteConversationPersistenceService : IConversationPersistenceServ
 
             // Query agent thread
             await using SqliteCommand command = connection.CreateCommand();
-            command.CommandText = LoadConversationSQL;
+            command.CommandText = LoadActiveConversationSQL;
             command.Parameters.AddWithValue("@agent_identifier", agentIdentifier);
 
             await using SqliteDataReader reader = await command.ExecuteReaderAsync();

--- a/Morgana/Morgana.Framework/Services/SQLiteConversationPersistedService.cs
+++ b/Morgana/Morgana.Framework/Services/SQLiteConversationPersistedService.cs
@@ -86,7 +86,7 @@ public class SQLiteConversationPersistenceService : IConversationPersistenceServ
 
     private const string LoadAgentConversationSQL =
         """
-        SELECT agent_thread FROM morgana WHERE agent_identifier = @agent_identifier AND is_active = 1;
+        SELECT agent_thread FROM morgana WHERE agent_identifier = @agent_identifier;
         """;
 
     private const string GetMostRecentActiveAgentSQL =

--- a/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
+++ b/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
@@ -83,7 +83,7 @@ public class ConversationController : ControllerBase
                 "manager", request.ConversationId);
 
             Records.ConversationCreated? conversationCreated = await manager.Ask<Records.ConversationCreated>(
-                new Records.CreateConversation(request.ConversationId));
+                new Records.CreateConversation(request.ConversationId, false));
 
             logger.LogInformation($"Started conversation {conversationCreated.ConversationId}");
 
@@ -173,7 +173,7 @@ public class ConversationController : ControllerBase
                 "manager", conversationId);
 
             Records.ConversationCreated? conversationCreated = await manager.Ask<Records.ConversationCreated>(
-                new Records.CreateConversation(conversationId));
+                new Records.CreateConversation(conversationId, true));
 
             // Restore active agent state in supervisor
             IActorRef supervisor = await actorSystem.ActorSelection(

--- a/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
+++ b/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
@@ -160,7 +160,7 @@ public class ConversationController : ControllerBase
 
             // Get most recent agent from database
             string? lastActiveAgent = await conversationPersistenceService
-                .GetMostRecentAgentAsync(conversationId);
+                .GetMostRecentActiveAgentAsync(conversationId);
 
             if (lastActiveAgent == null)
             {

--- a/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
+++ b/Morgana/Morgana.SignalR/Controllers/ConversationController.cs
@@ -158,7 +158,7 @@ public class ConversationController : ControllerBase
         {
             logger.LogInformation($"Resuming conversation {conversationId}");
 
-            // 1. Get most recent agent from database
+            // Get most recent agent from database
             string? lastActiveAgent = await conversationPersistenceService
                 .GetMostRecentAgentAsync(conversationId);
 
@@ -168,14 +168,14 @@ public class ConversationController : ControllerBase
                 return NotFound(new { error = "Conversation not found" });
             }
 
-            // 2. Create/get manager and supervisor
+            // Create/get manager and supervisor
             IActorRef manager = await actorSystem.GetOrCreateActor<ConversationManagerActor>(
                 "manager", conversationId);
 
             Records.ConversationCreated? conversationCreated = await manager.Ask<Records.ConversationCreated>(
                 new Records.CreateConversation(conversationId));
 
-            // 3. Restore active agent state in supervisor
+            // Restore active agent state in supervisor
             IActorRef supervisor = await actorSystem.ActorSelection(
                     $"/user/supervisor-{conversationId}")
                 .ResolveOne(TimeSpan.FromMilliseconds(500));


### PR DESCRIPTION
This PR finally gives Cauldron the ability to persist conversationId in ASP.NET **ProtectedLocalStorage** and talking with Morgana on the new "resume" route. We are now able to give **continuity to existing conversations**.

We don't actually show the past messages in the UI, because in Morgana the AI context and the ChatMessage store are isolated by agent. But we have a different landing experience and agents **have** the messages in their AgentThread rehydrated instances, so they are **aware** of the past.